### PR TITLE
initial CI setup

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -3,7 +3,7 @@ FROM finkandreas/dcomex-prototype_base:1.0
 COPY . /src
 
 RUN cd /src/korali \
-  && CC=gcc CXX=g++ meson setup build --prefix=/usr/local --buildtype=release -Donednn=true -Dmpi=true \
+  && CC=gcc CXX=g++ meson setup build --prefix=/usr/local --buildtype=release -Dmpi=true \
   && ninja -C build \
   && meson install -C build
 

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,0 +1,18 @@
+FROM finkandreas/dcomex-prototype_base:1.0
+
+COPY . /src
+
+RUN apt-get -y install pkg-config
+
+RUN cd /src/korali \
+  && CC=gcc CXX=g++ meson setup build --prefix=/usr/local --buildtype=release -Donednn=true -Dmpi=true \
+  && ninja -C build \
+  && meson install -C build
+
+ENV PYTHONPATH=/usr/local/lib/python3/dist-packages:$PYTONPATH
+
+# build msolve
+# not yet merged to main branch
+#RUN cd /src/MSolveApp/ISAAR.MSolve.MSolve4Korali \
+#  && dotnet build \
+#  && chmod ../../runTest.sh

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -2,8 +2,6 @@ FROM finkandreas/dcomex-prototype_base:1.0
 
 COPY . /src
 
-RUN apt-get -y install pkg-config
-
 RUN cd /src/korali \
   && CC=gcc CXX=g++ meson setup build --prefix=/usr/local --buildtype=release -Donednn=true -Dmpi=true \
   && ninja -C build \

--- a/ci/Dockerfile_base
+++ b/ci/Dockerfile_base
@@ -1,0 +1,49 @@
+FROM docker.io/nvidia/cuda:11.2.0-cudnn8-devel-ubuntu20.04
+
+ARG MPICH_VERSION=3.1.4
+
+RUN env TZ=Europe/Zurich DEBIAN_FRONTEND=noninteractive apt-get update \
+    && env TZ=Europe/Zurich DEBIAN_FRONTEND=noninteractive apt-get -y --fix-missing upgrade
+
+RUN apt-get -y install build-essential \
+    wget
+
+RUN cd /tmp \
+  && wget -q http://www.mpich.org/static/downloads/${MPICH_VERSION}/mpich-${MPICH_VERSION}.tar.gz \
+  && tar -xf mpich-${MPICH_VERSION}.tar.gz \
+  && cd mpich-${MPICH_VERSION} \
+  && ./configure --disable-fortran --enable-fast=all,O3 --prefix=/usr \
+  && echo "Using $(cat /proc/cpuinfo | grep 'model name' | wc -l) processes to build" \
+  && make -j$(cat /proc/cpuinfo | grep 'model name' | wc -l) \
+  && make install \
+  && ldconfig \
+  && cd .. \
+  && rm -Rf mpich-${MPICH_VERSION}{,.tar.gz}
+
+RUN env TZ=Europe/Zurich DEBIAN_FRONTEND=noninteractive \
+    apt-get -y install libgsl-dev \
+    python3-dev \
+    python3-pip \
+    python3-numpy \
+    python3-matplotlib \
+    python3-scipy \
+    python3-xlrd \
+    python3-pandas \
+    libmkldnn-dev \
+    apt-transport-https \
+    pkg-config
+
+RUN python3 -m pip install meson \
+    ninja \
+    cmake \
+    pybind11
+
+
+RUN cd /tmp \
+  && wget https://packages.microsoft.com/config/ubuntu/20.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb \
+  && dpkg -i packages-microsoft-prod.deb \
+  && rm packages-microsoft-prod.deb \
+  && apt-get update \
+  && apt-get install -y dotnet-sdk-6.0
+
+

--- a/ci/prototype.yml
+++ b/ci/prototype.yml
@@ -33,4 +33,4 @@ run_prototype_test:
     SLURM_NTASKS: 1
     PULL_IMAGE: 'YES'
     CSCS_REGISTRY_LOGIN: 'YES'
-    SLURM_TIMELIMIT: '00:05:00'
+    SLURM_TIMELIMIT: '00:15:00'

--- a/ci/prototype.yml
+++ b/ci/prototype.yml
@@ -4,6 +4,7 @@ stages:
 
 variables:
   PERSIST_IMAGE_NAME: ${CSCS_REGISTRY_PATH}/dcomex-prototype:1.0
+  GIT_SUBMODULE_STRATEGY: recursive
 
 build_software:
   tags:

--- a/ci/prototype.yml
+++ b/ci/prototype.yml
@@ -1,0 +1,35 @@
+stages:
+  - build # build stage is running on the Kubernetes cluster
+  - test  # test stage is running on Piz Daint
+
+variables:
+  PERSIST_IMAGE_NAME: ${CSCS_REGISTRY_PATH}/dcomex-prototype:1.0
+
+build_software:
+  tags:
+    - docker_jfrog
+  stage: build
+  script:
+    - "true"
+  variables:
+    DOCKERFILE: ci/Dockerfile
+
+run_prototype_test:
+  tags:
+    - daint-container
+  stage: test
+  image: ${PERSIST_IMAGE_NAME}
+  script:
+    # here should go the commands to run the actual applications, `ls` is just to show what is already in the container, to get an idea
+    - ls -lh /src
+    - ls -lh --recursive /usr/local/
+
+  variables:
+    USE_MPI: 'YES'
+    SLURM_PARTITION: 'normal'
+    SLURM_CONSTRAINT: 'gpu'
+    SLURM_JOB_NUM_NODES: 1
+    SLURM_NTASKS: 1
+    PULL_IMAGE: 'YES'
+    CSCS_REGISTRY_LOGIN: 'YES'
+    SLURM_TIMELIMIT: '00:05:00'


### PR DESCRIPTION
This is an initial setup for CI. The base image is currently hosted on dockerhub under my username, but I plan to create a separate pipeline where the base image can be updated, and pushed to the CSCS docker registry. this would allow us to update the base image only when dependencies are changing, which should not happen very often anyway.
Korali & MSovle on the other hand should will be built every time. For Korali I am not sure if this is the best approach, since we included it as a git submodule, i.e. potentially it is more static than MSolve.