### PR TITLE
use baseimage that is created via the baseimage pipeline

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,4 +1,5 @@
-FROM finkandreas/dcomex-prototype_base:1.0
+ARG REGISTRY_PATH=finkandreas
+FROM $REGISTRY_PATH/dcomex-prototype_base:1.0
 
 COPY . /src
 

--- a/ci/prototype.yml
+++ b/ci/prototype.yml
@@ -14,6 +14,7 @@ build_software:
     - "true"
   variables:
     DOCKERFILE: ci/Dockerfile
+    DOCKER_BUILD_ARGS: '["REGISTRY_PATH=${CSCS_REGISTRY_PATH}"]'
 
 run_prototype_test:
   tags:


### PR DESCRIPTION
This PR uses the baseimage that is being built in the `baseimage` pipeline.