### PR TITLE
add requirements file to read the docs: automodapi

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,3 @@
+python:
+  version: 3
+requirements_file: docs/requirements.txt

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,1 @@
+sphinx_automodapi


### PR DESCRIPTION
The read the docs build fails because of a missing module.