### PR TITLE
build containers publicly, build also baseimage as part of pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,18 @@ Usage: bio [-v] [-h] k1 mu time
 <p align="center"><img src="examples/bio/bio.svg" alt="MSolve results"/></p>
 <p align="center"><img src="examples/bio/mesh.png" alt="MSolve results"/></p>
 
+## Running manually
+To replicate CI runs manually it is possible to pull the containers by logging in to Piz Daint and execute the commands
+```
+module load sarus
+sarus pull IMAGE_NAME
+srun --pty -C gpu -A GROUP_ID -N1 -n1 sarus run --mpi --tty IMAGE_NAME bash
+```
+This will drop you to a shell on the compute node inside the container. From there you can
+replicate running the commands as in `ci/prototype.yml`.
+It is important to make sure that the container image names match the naming `*/public/*`, i.e.
+they must reside in a folder named public, only then anonymous access is possible.
+
 ## Directory structure
 
 * [CI](ci): definition of containerised build, test and deployment

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,5 +1,5 @@
-ARG REGISTRY_PATH=finkandreas
-FROM $REGISTRY_PATH/dcomex-prototype_base:1.0
+ARG BASE_IMAGE
+FROM $BASE_IMAGE
 COPY . /src
 WORKDIR /src/korali
 RUN meson setup build --prefix=/usr/local --buildtype=release -Dmpi=true

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /src/korali
 RUN meson setup build --prefix=/usr/local --buildtype=release -Dmpi=true
 RUN ninja -C build
 RUN meson install -C build
-ENV PYTHONPATH=/usr/local/lib/python3/dist-packages:$PYTONPATH
+ENV PYTHONPATH=/usr/local/lib/python3.8/site-packages:$PYTONPATH
 WORKDIR /src
 RUN make
 RUN chmod +x msolve/runTest.sh

--- a/ci/Dockerfile_base
+++ b/ci/Dockerfile_base
@@ -33,7 +33,7 @@ RUN env TZ=Europe/Zurich DEBIAN_FRONTEND=noninteractive \
     python3-matplotlib \
     python3-numpy \
     python3-pybind11 \
-    python3-scipy \
+    python3-scipy
 
 RUN cd /tmp \
   && wget https://packages.microsoft.com/config/ubuntu/20.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb \

--- a/ci/Dockerfile_base
+++ b/ci/Dockerfile_base
@@ -33,7 +33,8 @@ RUN env TZ=Europe/Zurich DEBIAN_FRONTEND=noninteractive \
     python3-matplotlib \
     python3-numpy \
     python3-pybind11 \
-    python3-scipy
+    python3-scipy \
+    python3-pandas
 
 RUN cd /tmp \
   && wget https://packages.microsoft.com/config/ubuntu/20.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb \

--- a/ci/prototype.yml
+++ b/ci/prototype.yml
@@ -1,24 +1,40 @@
+include:
+- remote: 'https://gitlab.com/cscs-ci/recipes/-/raw/master/templates/v2/.ci-ext.yml'
+
+
 stages:
+  - build_base # build stage is running on the Kubernetes cluster
   - build # build stage is running on the Kubernetes cluster
   - test  # test stage is running on Piz Daint
 
 variables:
-  PERSIST_IMAGE_NAME: ${CSCS_REGISTRY_PATH}/dcomex-prototype:1.0
+  PERSIST_IMAGE_NAME: ${CSCS_REGISTRY_PATH}/public/dcomex-prototype:$CI_COMMIT_SHORT_SHA
   GIT_SUBMODULE_STRATEGY: recursive
 
+build_base:
+  extends: .container-builder
+  stage: build_base
+  before_script:
+    - DOCKER_TAG=`sha256sum ci/Dockerfile_base | head -c 16`
+    - export PERSIST_IMAGE_NAME=$CSCS_REGISTRY_PATH/public/base/dcomex-prototype:$DOCKER_TAG
+    - echo "BASE_IMAGE=$PERSIST_IMAGE_NAME" > build.env
+  artifacts:
+    reports:
+      dotenv: build.env
+  variables:
+    DOCKERFILE: ci/Dockerfile_base
+    DOCKER_BUILD_ARGS: '["MPICH_VERSION=3.1.4"]'
+
+
 build_software:
-  tags:
-    - docker_jfrog
+  extends: .container-builder
   stage: build
-  script:
-    - "true"
   variables:
     DOCKERFILE: ci/Dockerfile
-    DOCKER_BUILD_ARGS: '["REGISTRY_PATH=${CSCS_REGISTRY_PATH}"]'
+    DOCKER_BUILD_ARGS: '["BASE_IMAGE=${BASE_IMAGE}"]'
 
 run_prototype_test:
-  tags:
-    - daint-container
+  extends: .container-runner-daint-gpu
   stage: test
   image: ${PERSIST_IMAGE_NAME}
   script:
@@ -30,9 +46,6 @@ run_prototype_test:
   variables:
     USE_MPI: 'YES'
     SLURM_PARTITION: 'normal'
-    SLURM_CONSTRAINT: 'gpu'
     SLURM_JOB_NUM_NODES: 1
     SLURM_NTASKS: 1
-    PULL_IMAGE: 'YES'
-    CSCS_REGISTRY_LOGIN: 'YES'
     SLURM_TIMELIMIT: '00:15:00'


### PR DESCRIPTION
This PR builds the base container as part of the pipeline itself
- The base container is only rebuild when the file `ci/Dockerfile_base` changes

The containers are pushed to names matching the scheme `*/public/*`, this way they can be accessed anonymously, i.e. without credentials.